### PR TITLE
Support monpreds

### DIFF
--- a/src/named_props.v
+++ b/src/named_props.v
@@ -1,5 +1,5 @@
 From iris.proofmode Require Import string_ident.
-From iris.proofmode Require Import tactics environments intro_patterns.
+From iris.proofmode Require Import tactics environments intro_patterns monpred.
 
 Set Default Proof Using "Type".
 
@@ -147,6 +147,16 @@ Global Arguments is_splittable {PROP P} : assert.
 Global Instance is_splittable_sep {PROP:bi} (P Q: PROP) :
   IsSplittable (P ∗ Q).
 Proof. Qed.
+
+Lemma make_monPred_at_named {I : biIndex} {PROP : bi} name (i : I) (P : monPred I PROP) (𝓟 : PROP) :
+  MakeMonPredAt i P 𝓟 →
+  MakeMonPredAt i (named name P) (named name 𝓟).
+Proof. done. Qed.
+
+(* This is not an instance since Coq would try and apply the instance at every
+step in the type class resolution since [named name P] unfolds to just [P].
+Instead we register a hint that only applies when the goal contains [named]. *)
+Global Hint Extern 0 (MakeMonPredAt _ (named _ _) _) => apply make_monPred_at_named : typeclass_instances.
 
 (** tc_is_inhabited succeeds if P is an inhabited typeclass and fails otherwise.
 *)

--- a/tests/named_props.ref
+++ b/tests/named_props.ref
@@ -2,3 +2,17 @@ The command has indeed failed with message:
 Tactic failure: iDeexHyp: "foo" not found.
 The command has indeed failed with message:
 Tactic failure: iExact: "HP" not found.
+"test_monpred_named"
+     : string
+1 goal
+  
+  PROP : bi
+  Haffine : BiAffine PROP
+  I : biIndex
+  P1 : PROP
+  P2 : monPred I PROP
+  i : I
+  ============================
+  --------------------------------------∗
+  "H1" ∷ P1 ∗ "H2" ∷ P2 i -∗ P1 ∗ P2 i
+  

--- a/tests/named_props.v
+++ b/tests/named_props.v
@@ -1,4 +1,4 @@
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import tactics monpred.
 From iris_named_props Require Import named_props.
 
 Set Default Proof Using "All".
@@ -303,6 +303,17 @@ Section tests.
       (* should recover the same context (modulo renaming of anonymous
       hypotheses) *)
       iFrame.
+  Qed.
+
+  Check "test_monpred_named".
+  Example test_monpred_named {I : biIndex} P1 (P2 : monPred I PROP) :
+    "H1" ∷ ⎡P1⎤ ∗ "H2" ∷ P2 -∗ ⎡P1⎤ ∗ P2.
+  Proof.
+    iStartProof PROP.
+    iIntros (i).
+    Show.
+    iNamed 1.
+    iFrame "H1 H2".
   Qed.
 
 End tests.


### PR DESCRIPTION
When using propositions of the form `monPred I PROP`, starting the proof mode with `iStartProof PROP` (i.e. starting a proof with the underlying `PROP` as the type of propositions) names are not carried properly into the proofmode. The test in this MR probably shows the issue.

Intuitively the solution is to add an instance for `MakeMonPredAt`. But since `named` isn't sealed this doesn't work. Instead this MR adds a hint to the type class search that seems to work well 🙂