### PR TITLE
Maintenance & restore CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         coq:
           - "dev"
+          - "8.16"
           - "8.15"
           - "8.14"
-          - "8.13"
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
@@ -36,16 +36,6 @@ jobs:
             startGroup "Print opam config"
               opam config list; opam repo list; opam list
             endGroup
-  build-release:
-    name: build (released iris, coq dev)
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v2
-      - uses: coq-community/docker-coq-action@v1
-        with:
-          custom_image: "coqorg/coq:dev"
 # See also:
 # https://github.com/coq-community/docker-coq-action#readme
 # https://github.com/erikmd/docker-coq-github-action-demo

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -14,12 +14,12 @@ NORMALIZER:=test-normalizer.sed
 test: $(TESTFILES:.v=.vo)
 # Make sure all Instance/Argument/Hint are qualified.
 	$(HIDE)for FILE in $(VFILES); do \
-	  if egrep '^\s*(Instance|Arguments|Remove|Hint (Extern|Constructors|Resolve|Immediate|Mode|Opaque|Transparent|Unfold))\s' "$$FILE"; then echo "ERROR: $$FILE contains unqualified 'Instance'/'Arguments'/'Hint'."; echo; exit 1; fi \
+	  if grep -E '^\s*(Instance|Arguments|Remove|Hint (Extern|Constructors|Resolve|Immediate|Mode|Opaque|Transparent|Unfold))\s' "$$FILE"; then echo "ERROR: $$FILE contains unqualified 'Instance'/'Arguments'/'Hint'."; echo; exit 1; fi \
 	done
 .PHONY: test
 
 COQ_TEST=$(COQTOP) $(COQDEBUG) -batch -test-mode
-COQ_MINOR_VERSION:=$(shell echo "$(COQ_VERSION)" | egrep '^[0-9]+\.[0-9]+\b' -o)
+COQ_MINOR_VERSION:=$(shell echo "$(COQ_VERSION)" | grep -E '^[0-9]+\.[0-9]+\b' -o)
 
 tests/.coqdeps.d: $(TESTFILES)
 	$(SHOW)'COQDEP TESTFILES'

--- a/iris-named-props.opam
+++ b/iris-named-props.opam
@@ -15,7 +15,7 @@ those names to automatically introduce all the conjuncts in a definition.
 
 depends: [
   "coq" {>= "8.13"}
-  "coq-iris" {>= "dev.2022-11-24.1.4d4f4192" | (>= "4.0.0" & < "5.0") | = "dev"}
+  "coq-iris" {>= "dev.2022-11-24.1.4d4f4192" | (> "4.0.0" & < "5.0") | = "dev"}
 ]
 
 build: [make "-j%{jobs}%"]


### PR DESCRIPTION
This restores CI for the main branch, wrt the development version of Iris (I left out Coq 8.13 as support for it in Iris is soon going to be dropped).

I moved the github action workflow testing wrt released iris to the GH action file of the iris4.0 branch I just pushed. (I hope this makes sense GH actions-wise -- at least it seemed to work on my fork: the main and the iris4.0 branches do trigger a separate CI run for their respective GH action file.)