### PR TITLE
fix deprecated scope delim in arg cmd

### DIFF
--- a/src/named_props.v
+++ b/src/named_props.v
@@ -142,7 +142,7 @@ Proof. Qed.
 should be split by [iNamed] as it traverses a proposition for named conjuncts.
 *)
 Class IsSplittable {PROP:bi} (P: PROP) := is_splittable {}.
-Global Arguments IsSplittable {_} _%I : assert.
+Global Arguments IsSplittable {_} _%_I : assert.
 Global Arguments is_splittable {PROP P} : assert.
 Global Instance is_splittable_sep {PROP:bi} (P Q: PROP) :
   IsSplittable (P ∗ Q).


### PR DESCRIPTION
fix the warning:
```
The '%' scope delimiter in 'Arguments' commands is deprecated, use '%_'
instead (available since 8.19). The '%' syntax will be reused in a future
version with the same semantics as in terms, that is adding scope to the
stack for all subterms. Code can be adapted with a script like: for f in
$(find . -name '*.v'); do sed '/Arguments/ s/%/%_/g' -i $f ; done
[argument-scope-delimiter,deprecated-since-8.19,deprecated,default]
```