### PR TITLE
WIP: enforce bumped Iris version

### DIFF
--- a/iris-named-props.opam
+++ b/iris-named-props.opam
@@ -15,7 +15,7 @@ those names to automatically introduce all the conjuncts in a definition.
 
 depends: [
   "coq" {>= "8.15"}
-  "coq-iris" {>= "dev.2023-05-10.0.30a7cd24" | (>= "4.1.0" & < "5.0") | = "dev"}
+  "coq-iris" {>= "dev.2025-06-05.1.71039151" | = "dev"}
 ]
 
 build: [make "-j%{jobs}%"]


### PR DESCRIPTION
With recent changes, this package relies on a development version of Iris. This PR reflects that in the `opam` file.

I haven't been able to figure out how to do that (too much `opam` magic for me; I wasn't able to figure out how to pin a specific `dev.*` version), but someone (@tchajed ?) should make sure that the version I chose is actually actually sufficient. Alternatively, it might also be reasonable to just pin the (as of now) newest Iris dev version; That one is checked as part of the CI anyway.